### PR TITLE
add new keyword when throwing exception, to avoid call to undefined f…

### DIFF
--- a/src/Chalk.php
+++ b/src/Chalk.php
@@ -170,7 +170,7 @@ class Chalk
     public function __call($styleName, $arguments)
     {
         if (!$this->isValidStyle($styleName)) {
-            throw InvalidStyleException($styleName);
+            throw new InvalidStyleException($styleName);
         }
 
         list($offset, $styleName) = $this->parseStyleName($styleName);


### PR DESCRIPTION
add new keyword when throwing exception, to avoid call to undefined function

refer to last section of https://codereview.stackexchange.com/a/222490/120114